### PR TITLE
RNMT-3665 Fixes an issue with camera permissions on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixes
+- Fixes an issue with the camera permission request that was preventing scanning Cards with success in Android [RNMT-3665](https://outsystemsrd.atlassian.net/browse/RNMT-3665)
 
 ## [1.0.5] - 2019-04-12
 ### Changes

--- a/src/android/CardIoPlugin.java
+++ b/src/android/CardIoPlugin.java
@@ -61,11 +61,12 @@ public class CardIoPlugin extends CordovaPlugin {
                         scanCardLogic(args);
                 }
             }, REQUEST_PERMISSION, Manifest.permission.CAMERA);
-        } else
+
+            return true;
+
+        } else {
             return scanCardLogic(args);
-
-        return false;
-
+        }
     }
 
     private boolean scanCardLogic(JSONArray args) {


### PR DESCRIPTION
### Description

This pull request introduces a fix for the camera permissions handler for Android applications, where the plugin was incorrectly invoking the fail callback whenever the permission popup appeared, which was blocking users from successfully scan cards.

Solves: https://outsystemsrd.atlassian.net/browse/RNMT-3665
