### PR TITLE
Fix ::: Android 15 Edge-to-Edge

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixes
+- Android 15 - Fix cropping of Card IO screens due to Edge-to-Edge
 
 ## [1.1.1]
 ### Fixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.1.2]
 ### Fixes
 - Android 15 - Fix cropping of Card IO screens due to Edge-to-Edge
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "com.os.mobile.cardio",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Plugin Read Card ID and to Scan Documents",
   "cordova": {
     "id": "com.os.mobile.cardio",

--- a/plugin.xml
+++ b/plugin.xml
@@ -28,6 +28,7 @@
             </feature>
         </config-file>
         <source-file src="src/android/CardIoPlugin.java" target-dir="src/com/os/mobile/cardioplugin" />
+        <source-file src="src/android/CardIoActivityLifecycleCallbacks.java" target-dir="src/com/os/mobile/cardioplugin" />
         <framework src="src/android/cardio.gradle" custom="true" type="gradleReference" />
     </platform> <!-- /Android -->
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -2,7 +2,7 @@
 
 <plugin xmlns="http://apache.org/cordova/ns/plugins/1.0"
            id="com.os.mobile.cardio"
-      version="1.1.1">
+      version="1.1.2">
     <name>Card.io Cordova Plugin</name>
     <description>Plugin Read Card ID and to Scan Documents</description>
     <author>OutSystems</author>

--- a/src/android/CardIoActivityLifecycleCallbacks.java
+++ b/src/android/CardIoActivityLifecycleCallbacks.java
@@ -1,0 +1,67 @@
+package com.os.mobile.cardioplugin;
+
+import android.app.Activity;
+import android.app.Application;
+import android.os.Bundle;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.core.graphics.Insets;
+import androidx.core.view.ViewCompat;
+import androidx.core.view.WindowInsetsCompat;
+
+import io.card.payment.CardIOActivity;
+import io.card.payment.DataEntryActivity;
+
+/**
+ * Listener for Card IO Activities lifecycle.
+ * The main goal being to fix the insets on Android 15 (since edge-to-edge is enforced with targetSdk=35).
+ * Checks when an activity is in foreground (onResume), and applying the proper insets to the root layout.
+ * This way, there is no need to provide a custom implementation/fork of Card IO.
+ */
+public class CardIoActivityLifecycleCallbacks implements Application.ActivityLifecycleCallbacks {
+    @Override
+    public void onActivityCreated(@NonNull Activity activity, @Nullable Bundle bundle) {}
+
+    @Override
+    public void onActivityStarted(@NonNull Activity activity) {}
+
+
+    @Override
+    public void onActivityResumed(@NonNull Activity activity) {
+        if (!(activity instanceof CardIOActivity || activity instanceof DataEntryActivity)) {
+            return;
+        }
+        View activityLayoutRootView =
+                ((ViewGroup) activity.getWindow().getDecorView().getRootView()).getChildAt(0);
+        if (activityLayoutRootView != null) {
+            ViewCompat.setOnApplyWindowInsetsListener(
+                    activityLayoutRootView,
+                    (v, insets) -> {
+                        Insets systemBarInsets = insets.getInsets(WindowInsetsCompat.Type.systemBars());
+                        v.setPadding(
+                                systemBarInsets.left,
+                                systemBarInsets.top,
+                                systemBarInsets.right,
+                                systemBarInsets.bottom
+                        );
+                        return insets;
+                    }
+            );
+        }
+    }
+
+    @Override
+    public void onActivityPaused(@NonNull Activity activity) {}
+
+    @Override
+    public void onActivityStopped(@NonNull Activity activity) {}
+
+    @Override
+    public void onActivitySaveInstanceState(@NonNull Activity activity, @NonNull Bundle bundle) {}
+
+    @Override
+    public void onActivityDestroyed(@NonNull Activity activity) {}
+}

--- a/src/android/CardIoPlugin.java
+++ b/src/android/CardIoPlugin.java
@@ -33,6 +33,8 @@ public class CardIoPlugin extends CordovaPlugin {
 
     private CallbackContext callbackContext;
 
+    private CardIoActivityLifecycleCallbacks mCurrentActivityCallback = null;
+
     @Override
     public boolean execute(String action, JSONArray args, CallbackContext callbackContext) throws JSONException {
         this.callbackContext = callbackContext;
@@ -83,6 +85,7 @@ public class CardIoPlugin extends CordovaPlugin {
                 scanIntent.putExtra(CardIOActivity.EXTRA_REQUIRE_POSTAL_CODE, requirePostalCode); // default: false
                 // scanIntent.putExtra(CardIOActivity.EXTRA_SUPPRESS_MANUAL_ENTRY, true);
                 // scanIntent.putExtra(CardIOActivity.EXTRA_KEEP_APPLICATION_THEME, true);
+                observeActivityLifecycle();
                 this.cordova.startActivityForResult(this, scanIntent, CARDIO_PLUGIN_SCAN_CARD_REQUEST_CODE);
                 return true;
             } catch (JSONException e) {
@@ -93,6 +96,18 @@ public class CardIoPlugin extends CordovaPlugin {
             this.respondError(ERROR_CANT_READ_CARD, "Can't scan with camera.");
             return false;
         }
+    }
+
+    private void observeActivityLifecycle() {
+        if (mCurrentActivityCallback != null) {
+            this.cordova.getActivity().getApplication().unregisterActivityLifecycleCallbacks(
+                    mCurrentActivityCallback
+            );
+        }
+        mCurrentActivityCallback = new CardIoActivityLifecycleCallbacks();
+        this.cordova.getActivity().getApplication().registerActivityLifecycleCallbacks(
+                mCurrentActivityCallback
+        );
     }
 
     @Override

--- a/src/android/cardio.gradle
+++ b/src/android/cardio.gradle
@@ -1,7 +1,9 @@
 repositories {
+    google()
     mavenCentral()
 }
 
 dependencies {
     implementation 'io.card:android-sdk:5.1.2'
+    implementation 'androidx.appcompat:appcompat:1.6.1'
 }


### PR DESCRIPTION
## Description

- Properly support edge-to-edge on Android 15 devices (with targetSdk=35) by adding the correct padding to Card IO activities root layout. 
- To avoid forking and generating a new version of the [card io SDK](https://github.com/card-io/card.io-Android-source) (although we may not have a choice in order to support 16KB page size devices) - We implement `ActivityLifecycleCallbacks` to detect when the activities come to foreground - See src/android/CardIoActivityLifecycleCallbacks.java
- The UI for the manual input `DataEntryActivity` does not look fully edge-to-edge, it looks the same as Android < 15. To make further changes would require forking card-io repository, but seems unnecessary for a UI bug, and this PR fixes the issue which is the main purpose.

## Context

https://outsystemsrd.atlassian.net/wiki/spaces/RDME/pages/4426137659/iOS+18+Android+15+Assessment

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [X] Android
- [ ] iOS
- [ ] JavaScript

## Tests

Tested on Android 15 devices with target 35 Barcode Sample app to confirm that the barcode scanning screen is now properly edge-to-edge. 

## Screenshots (if appropriate)

Note that the frame size changed slightly because the measurement now includes the window insets.

| Type           | Before         | After           |
| ----------- | ----------- | ----------- |
| Pixel Android 15 camera   | ![before_cardio_camera_android15](https://github.com/user-attachments/assets/dfab6df5-e950-4afd-bee7-bf54dc5c45e5) | ![after_cardio_camera_android15](https://github.com/user-attachments/assets/644d0bc0-e471-48e8-93a3-11279d66b3c8) |
| Pixel Android 15 manual   | ![before_cardio_keyboard_android15](https://github.com/user-attachments/assets/dd76e8bf-b99e-478a-b8ea-76ae274f00a8) | ![after_cardio_keyboard_android15](https://github.com/user-attachments/assets/21f42c85-85a7-44ba-8e8c-72d771781312) |


## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
- [ ] Documentation has been updated accordingly
