### PR TITLE
RMET-3854 - Include `NSCameraUsageDescription` in `Info.plist` file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [1.1.2]
 ### Fixes
+- iOS - include `NSCameraUsageDescription` in Info.plist file
+
+### Fixes
 - Android 15 - Fix cropping of Card IO screens due to Edge-to-Edge
 
 ## [1.1.1]

--- a/plugin.xml
+++ b/plugin.xml
@@ -40,6 +40,12 @@
             </feature>
         </config-file>
 
+        <!-- Usage descriptions -->
+        <preference name="CAMERA_USAGE_DESCRIPTION" default=" " />
+         <config-file target="*-Info.plist" parent="NSCameraUsageDescription">
+             <string>$CAMERA_USAGE_DESCRIPTION</string>
+         </config-file>
+
         <!-- Plugin Implementation -->
         <header-file src="src/ios/CardioPlugin.h" />
         <source-file src="src/ios/CardioPlugin.m"/>


### PR DESCRIPTION
## Description

- include `NSCameraUsageDescription` in Info.plist.
- this solves an issue where the app was crashing when opening the Card IO scanner view.

## Context

References: https://outsystemsrd.atlassian.net/browse/RMET-3854

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [x] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [ ] Android
- [x] iOS
- [ ] JavaScript

## Tests

Tested on iPhone 11 with iOS 18.1

## Screenshots (if appropriate)

## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [x] Pull request title follows the format `RNMT-XXXX <title>`
- [x] Code follows code style of this project
- [x] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
- [ ] Documentation has been updated accordingly
