### PR TITLE
RMET-3602 ::: Android ::: Support for 16KB page size

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixes
+- Android - Support 16KB page size
+
 ## [1.1.2]
 ### Fixes
 - iOS - include `NSCameraUsageDescription` in Info.plist file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## Unreleased
 ### Fixes
-- Android - Support 16KB page size
+- Android - Support 16KB page size (https://outsystemsrd.atlassian.net/browse/RMET-3602)
 
 ## [1.1.2]
 ### Fixes

--- a/plugin.xml
+++ b/plugin.xml
@@ -29,7 +29,7 @@
         </config-file>
         <source-file src="src/android/CardIoPlugin.java" target-dir="src/com/os/mobile/cardioplugin" />
         <source-file src="src/android/CardIoActivityLifecycleCallbacks.java" target-dir="src/com/os/mobile/cardioplugin" />
-        <lib-file src="src/android/libs/card.io-custom-support16kb-page-size.aar" />
+        <lib-file src="src/android/libs/card.io-5.5.1-OS1.aar.aar" />
         <framework src="src/android/cardio.gradle" custom="true" type="gradleReference" />
     </platform> <!-- /Android -->
 

--- a/plugin.xml
+++ b/plugin.xml
@@ -29,6 +29,7 @@
         </config-file>
         <source-file src="src/android/CardIoPlugin.java" target-dir="src/com/os/mobile/cardioplugin" />
         <source-file src="src/android/CardIoActivityLifecycleCallbacks.java" target-dir="src/com/os/mobile/cardioplugin" />
+        <lib-file src="src/android/libs/card.io-custom-support16kb-page-size.aar" />
         <framework src="src/android/cardio.gradle" custom="true" type="gradleReference" />
     </platform> <!-- /Android -->
 

--- a/src/android/cardio.gradle
+++ b/src/android/cardio.gradle
@@ -4,6 +4,6 @@ repositories {
 }
 
 dependencies {
-    implementation files("libs/card.io-custom-support16kb-page-size.aar")
+    implementation files("libs/card.io-5.5.1-OS1.aar.aar")
     implementation 'androidx.appcompat:appcompat:1.6.1'
 }

--- a/src/android/cardio.gradle
+++ b/src/android/cardio.gradle
@@ -4,6 +4,6 @@ repositories {
 }
 
 dependencies {
-    implementation 'io.card:android-sdk:5.1.2'
+    implementation files("libs/card.io-custom-support16kb-page-size.aar")
     implementation 'androidx.appcompat:appcompat:1.6.1'
 }


### PR DESCRIPTION
## Description

Fix the crashes on Android 16KB page size devices, by updating and rebuilding the card-io library for Android.

The following steps were taken
- Recompile the Open CV from Source, with support for 16 KB. Because that support is not yet in an official release, used the branch from this PR - https://github.com/opencv/opencv/pull/26057 - Created this script - https://github.com/OS-pedrogustavobilro/card.io-Android-source/blob/fix/RMET-3602/support-16KB-page-size/opencv/build_opencv_16kb.sh 
- Update the openCV version (including the C++ header files) being used in card io. Also updated Eigen C++ version - https://github.com/OS-pedrogustavobilro/card.io-dmz/tree/fix/RMET-3602/android15-16kb-page-size
- Updated openCV .so files; updated NDK and gradle version being used for Card IO to be compiled with 16KB page size support - https://github.com/OS-pedrogustavobilro/card.io-Android-source/tree/fix/RMET-3602/support-16KB-page-size
- Generated a new .aar (from latest version 5.5.1, previously we used 5.1.2), added in this PR. 

### Note regarding binary size

Due to all these changes, it seems the generated APK of the Sample app grew quite a bit - from ~40MB to ~97MB - Steps were already taken to reduce it from 160MB down to 97MB, and a big chunk of the increase come from OpenCV .so files for x86 and x86_64 architectures, which are barely present in real Android devices there days. So for arm cpu architectures, the actual increase of the apk to download (in e.g. Google Play) is much smaller.

## Context

- https://outsystemsrd.atlassian.net/browse/RMET-3602
- https://outsystemsrd.atlassian.net/wiki/spaces/RDME/pages/4426137659/iOS+18+Android+15+Assessment
- https://github.com/OutSystems/card.io-dmz/pull/1
- https://github.com/OutSystems/card.io-Android-source/pull/1

## Type of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply -->
- [X] Fix (non-breaking change which fixes an issue)
- [ ] Feature (non-breaking change which adds functionality)
- [ ] Refactor (cosmetic changes)
- [ ] Breaking change (change that would cause existing functionality to not work as expected)

## Platforms affected
- [X] Android
- [ ] iOS
- [ ] JavaScript

## Tests

Tested on Android 15 devices with and without 16KB page size, with a MABS 11 build of the Card IO sample app.

For the device with 16KB page size, used an emulator.


## Checklist
<!--- Go over all the following items and put an `x` in all the boxes that apply -->
- [ ] Pull request title follows the format `RNMT-XXXX <title>`
- [ ] Code follows code style of this project
- [ ] CHANGELOG.md file is correctly updated
- [ ] Changes require an update to the documentation
- [ ] Documentation has been updated accordingly
