### PR TITLE
chore(android): Update Card IO SDK with opt-out for large screens

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Features
 - Android - Support predictive back animations for Android 13 and above (https://outsystemsrd.atlassian.net/browse/RMET-4337)
 
+### Chores
+- Android - Opt-out flag to allow for re-orientation of the scanner screen on large screens for apps targetting Android 16 (https://outsystemsrd.atlassian.net/browse/RMET-4342)
+
 ## [1.1.3]
 ### Fixes
 - Android - Support 16KB page size (https://outsystemsrd.atlassian.net/browse/RMET-3602)

--- a/plugin.xml
+++ b/plugin.xml
@@ -28,7 +28,7 @@
             </feature>
         </config-file>
         <source-file src="src/android/CardIoPlugin.java" target-dir="src/com/os/mobile/cardioplugin" />
-        <lib-file src="src/android/libs/card.io-5.5.1-OS2.aar" />
+        <lib-file src="src/android/libs/card.io-5.5.1-OS3.aar" />
         <framework src="src/android/cardio.gradle" custom="true" type="gradleReference" />
     </platform> <!-- /Android -->
 

--- a/src/android/cardio.gradle
+++ b/src/android/cardio.gradle
@@ -4,6 +4,6 @@ repositories {
 }
 
 dependencies {
-    implementation files("libs/card.io-5.5.1-OS2.aar")
+    implementation files("libs/card.io-5.5.1-OS3.aar")
     implementation 'androidx.appcompat:appcompat:1.6.1'
 }


### PR DESCRIPTION
Target Android 16 specific changes.

References:
1. https://github.com/OutSystems/card.io-Android-source/pull/3
2. https://outsystemsrd.atlassian.net/browse/RMET-4342